### PR TITLE
Move from ctsdio to iostream and fix make issue.

### DIFF
--- a/bst/bst.cpp
+++ b/bst/bst.cpp
@@ -1,8 +1,10 @@
-#include <stdio.h>
+#include <iostream>
 #include <stdlib.h>
 
 #define TEST_SIZE 10
 #define TEST_SPACE 50
+
+using namespace std;
 
 struct Node
 {
@@ -15,13 +17,13 @@ struct Node
         left = NULL;
         right = NULL;
     }
-    
+
     /** @brief Inserts an integer into the subtree rooted at this node.
-    
+
     Does not allow duplicate entries.
-    
+
     @return whether or not the entry was successfully inserted.
-    
+
     */
     bool insert(int val)
     {
@@ -54,11 +56,11 @@ struct Node
             }
         }
     }
-    
+
     /** @brief Finds an integer in the subtree rooted at this node.
-    
+
     @return whether or not the entry exists in this subtree.
-    
+
     */
     bool find(int val)
     {
@@ -101,23 +103,23 @@ public:
     {
         root = NULL;
     }
-    
+
     /** @brief Inserts an integer into this tree.
-    
+
     Does not allow duplicate entries.
-    
+
     @return whether or not the entry was successfully inserted.
-    
+
     */
     bool insert(int val)
     {
         return root->insert(val);
     }
-    
+
      /** @brief Finds an integer in this tree.
-    
+
     @return whether or not the entry exists in this tree.
-    
+
     */
     bool find(int val)
     {
@@ -129,35 +131,37 @@ int main(int argc, char ** argv)
 {
     BinarySearchTree b;
     srand(42);
-    
+
     // first insert some test numbers
-    printf("\n\nadding %d numbers\n\n", TEST_SIZE);
+    cout << endl << endl
+         << "adding " << TEST_SIZE << " numbers" << endl << endl;
     for(int i = 0; i < TEST_SIZE; i++)
     {
         int k = rand() % TEST_SPACE;
-        printf("Inserting %d... ", k);
+        cout << "Inserting " << k << "... ";
         bool s = b.insert(k);
         if(s)
         {
-            printf("OK\n");
+            cout << "OK" << endl;
         }
         else
         {
-            printf("already in\n");
+            cout << "already in" << endl;
         }
     }
-    
+
     // now print out all the numbers in the tree
     // (by finding all possible numbers, not by traversing the tree)
-    printf("\n\nok, now printing contents (the slow way)\n\n");
+    cout << endl << endl
+         << "ok, now printing contents (the slow way)" << endl << endl;
     for(int j = 0; j < TEST_SPACE; j++)
     {
         if(b.find(j))
         {
-            printf("%d ", j);
+            cout << j;
         }
     }
-    
-    printf("\n\nall done\n\n");
+
+    cout << endl << endl << "all done" << endl << endl;
     return 0;
 }

--- a/maze/src/BreadthFirstSolver.hpp
+++ b/maze/src/BreadthFirstSolver.hpp
@@ -46,8 +46,8 @@
 #ifndef __BREADTHFIRSTSOLVER_H__
 #define __BREADTHFIRSTSOLVER_H__
 
-#include <cstdio>
 #include <vector>
+#include <iostream>
 #include "MazeSolverBase.hpp"
 #include "CoordinateQueue.hpp"
 

--- a/maze/src/DepthFirstSolver.hpp
+++ b/maze/src/DepthFirstSolver.hpp
@@ -46,8 +46,8 @@
 #ifndef __DEPTHFIRSTSOLVER_H__
 #define __DEPTHFIRSTSOLVER_H__
 
-#include <cstdio>
 #include <vector>
+#include <iostream>
 #include "MazeSolverBase.hpp"
 #include "CoordinateStack.hpp"
 

--- a/maze/src/MazeSolverApp.hpp
+++ b/maze/src/MazeSolverApp.hpp
@@ -48,7 +48,7 @@
 
 #include <SDL.h>
 #include <SDL_gfxPrimitives.h>
-#include <cstdio>
+#include <iostream>
 #include "RecursiveBacktracker.hpp"
 #include "MazeGrid.hpp"
 #include "MazeSolverBase.hpp"

--- a/maze/src/RecursiveBacktracker.cpp
+++ b/maze/src/RecursiveBacktracker.cpp
@@ -73,24 +73,24 @@ void RecursiveBacktracker::ascii_print()
 
     for (x = 0; x < WIDTH * 2; x++)
     {
-        printf("_");
+        cout << "_";
     }
 
-    printf("\n");
+    cout << endl;
 
     for (y = 0; y < HEIGHT; y++)
     {
-        printf("|");
+        cout << "|";
 
         for (x = 0; x < WIDTH; x++)
         {
             if ((maze->grid[x][y] & S) != 0)
             {
-                printf(" ");
+                cout << " ";
             }
             else
             {
-                printf("_");
+                cout << "_";
             }
 
             if ((maze->grid[x][y] & E) != 0)
@@ -98,20 +98,20 @@ void RecursiveBacktracker::ascii_print()
                 if (((maze->grid[x][y] |
                     maze->grid[x+1][y]) & S) != 0)
                 {
-                    printf(" ");
+                    cout << " ";
                 }
                 else
                 {
-                    printf("_");
+                    cout << "_";
                 }
             }
             else
             {
-                printf("|");
+                cout << "|";
             }
         }
 
-        printf("\n");
+        cout << endl;
     }
 }
 

--- a/maze/src/RecursiveBacktracker.hpp
+++ b/maze/src/RecursiveBacktracker.hpp
@@ -47,7 +47,7 @@
 #define __RECURSIVEBACKTRACKER_H__
 
 #include <cstdlib>
-#include <cstdio>
+#include <iostream>
 #include <ctime>
 #include "MazeGrid.hpp"
 #include "common.hpp"

--- a/quadtree/.gitignore
+++ b/quadtree/.gitignore
@@ -1,1 +1,2 @@
 bin/*
+!bin/.dummy

--- a/quadtree/src/Quadtree.cpp
+++ b/quadtree/src/Quadtree.cpp
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Functions for a quadtree.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #include "Quadtree.h"
@@ -116,8 +116,8 @@ query *Quadtree::Query(coordinate *center, float radius)
 {
     vector<coordinate*> points;
     vector<rect*> boxes;
-    
+
     query *q = new query(points, boxes);
-    
+
     return q;
 }

--- a/quadtree/src/Quadtree.h
+++ b/quadtree/src/Quadtree.h
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Definitions for a quadtree.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #ifndef __QUADTREE_H__

--- a/quadtree/src/QuadtreeNode.cpp
+++ b/quadtree/src/QuadtreeNode.cpp
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Functions for a quadtree node.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #include "QuadtreeNode.h"
@@ -96,7 +96,7 @@ rect *QuadtreeNode::NodeRect()
  */
 void QuadtreeNode::Insert(coordinate *c)
 {
-    
+
 }
 
 

--- a/quadtree/src/QuadtreeNode.h
+++ b/quadtree/src/QuadtreeNode.h
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Definitions for a quadtree node.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #ifndef __QUADTREENODE_H__

--- a/quadtree/src/QuadtreeVisualizerApp.cpp
+++ b/quadtree/src/QuadtreeVisualizerApp.cpp
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Functions for main application class.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #include "QuadtreeVisualizerApp.h"
@@ -57,7 +57,7 @@ QuadtreeVisualizerApp::QuadtreeVisualizerApp()
 
     srand(time(NULL));
     qtree = NULL;
-    
+
     Initialize();
 }
 
@@ -68,7 +68,7 @@ QuadtreeVisualizerApp::~QuadtreeVisualizerApp()
 {
     if (qtree)
         delete qtree;
-} 
+}
 
 
 /**
@@ -79,14 +79,14 @@ QuadtreeVisualizerApp::~QuadtreeVisualizerApp()
 int QuadtreeVisualizerApp::OnExecute()
 {
     SDL_Event Event;
-    
+
     if(OnInit() == false)
     {
         return -1;
     }
 
     OnRender(NULL);
- 
+
     while (running)
     {
         while(SDL_PollEvent(&Event))
@@ -94,9 +94,9 @@ int QuadtreeVisualizerApp::OnExecute()
             OnEvent(&Event);
         }
     }
- 
+
     OnCleanup();
- 
+
     return 0;
 }
 
@@ -113,16 +113,16 @@ bool QuadtreeVisualizerApp::OnInit()
     {
         return false;
     }
- 
-    if((surf = SDL_SetVideoMode(SCREENSIZE, SCREENSIZE, 32, 
+
+    if((surf = SDL_SetVideoMode(SCREENSIZE, SCREENSIZE, 32,
     SDL_HWSURFACE | SDL_DOUBLEBUF)) == NULL)
     {
         return false;
     }
-    
+
     /* This is necessary to receive Unicode keycodes. */
     SDL_EnableUNICODE(1);
- 
+
     return true;
 }
 
@@ -219,7 +219,7 @@ void QuadtreeVisualizerApp::OnRender(coordinate *query_point)
     for (unsigned int i = 0; i < points.size(); i++)
     {
         bool highlight = false;
-        
+
         for (unsigned int j = 0; j < points_to_highlight.size(); j++)
         {
             if (points[i] == points_to_highlight[j])
@@ -242,7 +242,7 @@ void QuadtreeVisualizerApp::OnRender(coordinate *query_point)
             (query_point->x + QUERY_RADIUS) * SCREENSIZE,
             (query_point->y + QUERY_RADIUS) * SCREENSIZE, 255, 128, 0, 255);
     }
-        
+
     SDL_Flip(surf);
 
     if (query_point)
@@ -269,7 +269,7 @@ void QuadtreeVisualizerApp::Initialize()
 {
     if (qtree)
         delete qtree;
-    
+
     qtree = new Quadtree(1.);
     AddOne();
 }
@@ -293,6 +293,6 @@ void QuadtreeVisualizerApp::AddOne()
  */
 int main(int argc, char* argv[])
 {
-    QuadtreeVisualizerApp app; 
+    QuadtreeVisualizerApp app;
     return app.OnExecute();
 }

--- a/quadtree/src/structs.h
+++ b/quadtree/src/structs.h
@@ -6,15 +6,15 @@
  * @copyright see License section
  *
  * @brief Common structures for use by quadtrees.
- * 
+ *
  * @section License
  * Copyright (c) 2013-2014 California Institute of Technology.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
  * * Redistributions in binary form must reproduce the above
@@ -24,7 +24,7 @@
  * * Neither the name of the  nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -38,9 +38,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The views and conclusions contained in the software and documentation are those
- * of the authors and should not be interpreted as representing official policies, 
+ * of the authors and should not be interpreted as representing official policies,
  * either expressed or implied, of the California Institute of Technology.
- * 
+ *
  */
 
 #ifndef __STRUCTS_H__
@@ -101,7 +101,7 @@ struct coordinate
 
 /**
  * @brief Struct for representing a rectangle in the 2-D plane.
- * 
+ *
  * The representation uses the coordinates of the upper left corner
  * and the coordinate of the bottom right corner.
  */
@@ -155,7 +155,7 @@ struct rect
 };
 
 /**
- * @brief Struct for containing information regarding points and 
+ * @brief Struct for containing information regarding points and
  *        rectangles that intersect a given square region
  */
 struct query


### PR DESCRIPTION
As per the new instructions on how to write to `STDOUT`, all instances of `printf` are replaced with `cout` and `#include <cstdio>` replaced with `#include <iostream>`. Trailing whitespace was removed, and a dummy file was added to the bin directory in quadtree so that make doesn't fail for lack of existence of a `bin` directory.
